### PR TITLE
Add time stamp to bundles

### DIFF
--- a/src/OSC/DateAndTime.extension.st
+++ b/src/OSC/DateAndTime.extension.st
@@ -1,0 +1,47 @@
+Extension { #name : #DateAndTime }
+" convert DateAndTime to NTPTimestamp for OSC bundles"
+{ #category : #'*LiveCoding' }
+DateAndTime >> asNTPTimeStamp [
+
+	| sec microsec ntpTimeStamp |
+	sec := self asUnixTime + 2208988800 asByteArrayOfSize: 4.
+	microsec := (self nanoSecond * (2 raisedToInteger: 32)
+	            / (10 raisedToInteger: 9)) asInteger asByteArrayOfSize: 4.
+	ntpTimeStamp := sec , microsec.
+
+	^ ntpTimeStamp
+]
+
+{ #category : #'*LiveCoding' }
+DateAndTime >> asNTPTimeStampWithLatency [
+" convert DateAndTime to NTPTimestamp for OSC bundles and adds 50 milliseconds of latency, to schedule messages ahead of time in SuperCollider"
+	| sec microsec ntpTimeStamp latency |
+	latency :=  50000000.
+	sec := self asUnixTime + 2208988800 asByteArrayOfSize: 4.
+	microsec := (self nanoSecond + latency * (2 raisedToInteger: 32)
+	            / (10 raisedToInteger: 9)) asInteger asByteArrayOfSize: 4.
+	ntpTimeStamp := sec , microsec.
+
+	^ ntpTimeStamp
+]
+
+{ #category : #'*LiveCoding' }
+DateAndTime >> microSecond [
+
+^ nanos / 1000
+]
+
+{ #category : #'*LiveCoding' }
+DateAndTime >> plusMicroseconds: microseconds [
+
+	"operand conforms to protocol Duration"
+
+	| extraSeconds extraNanoseconds |
+	
+	^ self class basicNew
+		  setJdn: julianDayNumber 
+		  seconds: seconds + extraSeconds 
+		  nano: nanos + extraNanoseconds 
+		  offset: self offset;
+		  yourself
+]

--- a/src/OSC/OSCBundle.class.st
+++ b/src/OSC/OSCBundle.class.st
@@ -31,6 +31,12 @@ OSCBundle >> print: somePackets onOSCStream: aStream [
 
 { #category : #printing }
 OSCBundle >> printTimeTagOnOSCStream: aStream [
-	"Not yet implemented, just print 8 empty bytes"
-	8 timesRepeat: [ aStream nextPut: 0 ]
+	"Add a timestamp with 50 milliseconds of latency, as necessary to use together with SuperCollider - remove addLatency: 50000000 or change the latency value
+	if necesaary"
+| dateAndTimeInBytes |
+	
+	dateAndTimeInBytes := (DateAndTime now addLatency: 50000000 ) asNTPTimeStamp  .
+	
+	aStream nextPutAll: dateInBytes  
+
 ]


### PR DESCRIPTION
implemented NTPtimestamp for OSC bundles - with a default latency 50 milliseconds to operate with SuperCollider/SuperDirt. 