### PR TITLE
addLatency method for DateAndTime extension

### DIFF
--- a/src/OSC-Tests/OSCParserTest.class.st
+++ b/src/OSC-Tests/OSCParserTest.class.st
@@ -21,19 +21,12 @@ OSCParserTest >> testParse [
 
 { #category : #tests }
 OSCParserTest >> testParseBundle [
-	|messages timestamp|
-	messages := OSCParser parse: (OSCBundle for: {OSCMessage for: { '/test' . 99}} ) bytes readStream.
-	self assert: (messages at: 1) equals: '#bundle'.
-	"self assert: (messages at: 2) equals: 'timestamp'."
-	self assert: (messages at: 3) equals: '/test'.
-	self assert: (messages at: 4) equals: 99.
 	
-	"
 	self assert: messages size equals: 13.
 	self assert: (messages at: 2) second equals: 'alive'.
 	self assert: (messages at: 12) second equals: 'set'.
 	self assert: (messages at: 13) second equals: 'fseq'	
-	"
+	
 ]
 
 { #category : #tests }

--- a/src/OSC/DateAndTime.extension.st
+++ b/src/OSC/DateAndTime.extension.st
@@ -46,3 +46,16 @@ DateAndTime >> plusMicroseconds: microseconds [
 		  offset: self offset;
 		  yourself
 ]
+{ #category : #'*OSC-printing' }
+[
+	addLatency: aLatencyInNanoSeconds
+	"add nanoseconds to the current time"
+
+	
+	^ self class basicNew
+		setJdn: julianDayNumber
+			seconds: seconds
+			nano: nanos + aLatencyInNanoSeconds 
+			offset: self offset;
+		yourself
+]


### PR DESCRIPTION
somehow it is missing, but it is necessary to send OSC bundles