### PR TITLE
fix on OSCServer terminate

### DIFF
--- a/src/OSC/OSCServer.class.st
+++ b/src/OSC/OSCServer.class.st
@@ -80,6 +80,8 @@ OSCServer >> receive: aByteStream [
 
 { #category : #'initialize-release' }
 OSCServer >> terminate [
-	socket notNil ifTrue: [socket destroy].
+	socket notNil ifTrue: [socket close.  "Explicitly close the socket"
+        socket destroy.
+        socket := nil.].
 	process notNil ifTrue: [process terminate]
 ]


### PR DESCRIPTION
the socket was not closed before being destroyed and this made impossible to reopen the OSCServer.
now it works fine.
I will work on Tests for this package in the next days